### PR TITLE
change awk field for address

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ vault policy write read_ns read_ns.hcl
 ### Back to Kube
 
 ```bash
-kubectl run shell-demo --generator=run-pod/v1 --rm -i --tty --serviceaccount=vault-auth --image ubuntu:latest --env="VAULT_ADDR=http://$(ip route get 1 | awk '{print $NF;exit}'):8200" --namespace="ns1"
+kubectl run shell-demo --generator=run-pod/v1 --rm -i --tty --serviceaccount=vault-auth --image ubuntu:latest --env="VAULT_ADDR=http://$(ip route get 1 | awk '{print $7;exit}'):8200" --namespace="ns1"
 
 # In shell
 apt-get update && apt-get install -y jq curl unzip wget less


### PR DESCRIPTION
When spinning up the container and setting the VAULT_ADDR variable, the awk command references "print $NF". However, this should be "print $7". The $NF, or number of fields, won't produce a valid ip address.